### PR TITLE
Fix identifier property assignement not correctly resolved

### DIFF
--- a/src/namedTransformer.ts
+++ b/src/namedTransformer.ts
@@ -35,11 +35,14 @@ function isIdentifiedDeclarationOrPropertyAssignment(ts: typeof TS, node: Node):
   );
 }
 
-function isIdentifiedDeclaration(ts: typeof TS, node: Node): node is VariableDeclaration | PropertyDeclaration {
+function isIdentifiedDeclaration(
+  ts: typeof TS,
+  node: Node
+): node is VariableDeclaration | PropertyDeclaration | PropertyAssignment {
   if (node === undefined) {
     return false;
   }
-  return ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node);
+  return ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node) || ts.isPropertyAssignment(node);
 }
 
 const namedFunction = 'named';
@@ -88,7 +91,10 @@ function visitNode(node: Node, pluginOptions: ConfigSet) {
   }
   if (ts.isIdentifier(node) && node.getText() === namePropertyBinding) {
     let n: Node = node;
-    while (!isIdentifiedDeclaration(ts, n)) {
+    while (
+      !isIdentifiedDeclaration(ts, n) ||
+      (ts.isPropertyAssignment(n) && n.initializer.getText() == namePropertyBinding)
+    ) {
       n = n.parent;
       if (n === undefined) {
         return node;

--- a/test/property-assingment.ts
+++ b/test/property-assingment.ts
@@ -1,9 +1,26 @@
-import { named as _ } from '../';
+import { ID, named as _ } from '../';
 
 const typed = {
   named1: _(id => ({ id: id, type: 'Type' })),
   named2: _(id => ({ id: id, type: 'Other Type' })),
+  named3: ID,
+};
+
+interface Type {
+  id: string;
+  label: string;
+}
+
+const type1: Type = { id: ID, label: 'label1' };
+const type2 = {
+  subType21: { id: ID, label: 'label21' },
+  subType22: { id: ID, label: 'label22' },
 };
 
 console.log(typed.named1.id === 'named1');
 console.log(typed.named2.id === 'named2');
+console.log(typed.named3 === 'typed');
+
+console.log(type1.id === 'type1');
+console.log(type2.subType21.id === 'subType21');
+console.log(type2.subType21.id === 'subType21');


### PR DESCRIPTION
Property assignment is not correctly resolved when an property is assigned with an object containing an ID (see test case).